### PR TITLE
Fix bug where valid satori image was not correctly parsed

### DIFF
--- a/satoricore/file/json.py
+++ b/satoricore/file/json.py
@@ -26,4 +26,4 @@ class SatoriJsoner(Serializer):
 	def loads(self, content):
 		# print (type(content))
 		# print(content)
-		return json.loads(content)
+		return json.loads(content.decode('utf8'))

--- a/satoricore/logger.py
+++ b/satoricore/logger.py
@@ -4,7 +4,7 @@ try:
 	from termcolor import colored
 except ImportError:
 	def colored(*args, **kwargs):
-		return args[0] 
+		return args[0]
 
 LOG_LEVEL = logging.INFO
 


### PR DESCRIPTION
Generating an image with default settings with satori-imager and then trying to parse it with satori-file, generated errors where none of the supplied serializers were able to correctly parse the file.